### PR TITLE
ci: separa testes unitários e implementa lógica fail-fast

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -38,10 +38,28 @@ jobs:
       - name: Run security audit
         run: npm audit --audit-level=high
 
+  unit_tests:
+    name: Unit Tests & Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - name: Run Tests with Coverage
+        run: npm run test:coverage
+      - name: Upload Coverage Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lcov-report
+          path: coverage/lcov.info
+
   # 2. Build da Aplicação
   build:
     name: Build Application
-    needs: [lint, security_audit]
+    needs: [lint, security_audit, unit_tests]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -79,7 +97,7 @@ jobs:
 
   sonar:
     name: SonarCloud (SAST)
-    needs: build
+    needs: [build, unit_tests]
     if: success()
     runs-on: ubuntu-latest
     steps:
@@ -91,8 +109,11 @@ jobs:
           node-version: 20
           cache: 'npm'
       - run: npm ci
-      - name: Run Tests with Coverage
-        run: npm run test:coverage
+      - name: Download Coverage Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: lcov-report
+          path: coverage/
       - name: SonarCloud Scan
         run: npx sonar-scanner -Dsonar.login=$SONAR_TOKEN
         env:
@@ -118,7 +139,7 @@ jobs:
           path: .next
       - name: Verify Downloaded Artifact
         run: ls -la .next
-      - name: 🚀 Start application
+      - name: Start application
         run: |
           npm start &
           npx wait-on http://localhost:3000 --timeout 60000
@@ -133,7 +154,7 @@ jobs:
             -r zap-report.html \
             -J zap-report.json
         continue-on-error: true
-      - name: 📤 Upload ZAP Report
+      - name: Upload ZAP Report
         uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,7 +4,6 @@ sonar.organization=lcapistrano25
 
 sonar.sources=src
 sonar.exclusions=**/*.test.ts,**/*.test.tsx,**/node_modules/**,**/.next/**
-sonar.coverage.exclusions=src/app/**,src/components/IncomeModal.tsx,src/components/ExpenseModal.tsx,src/components/Sidebar.tsx,src/components/mobile/**,src/components/forms/account-form.tsx,src/components/forms/category-form.tsx
 
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.typescript.tsconfigPath=tsconfig.json


### PR DESCRIPTION
- Criado job dedicado para testes unitários e geração de cobertura.
- Configurada dependência do build para interromper a pipeline em caso de falha nos testes.
- Otimizada análise do SonarCloud para utilizar artefatos de cobertura pré-gerados.
- Removidos emojis de alguns estágios para padronização.